### PR TITLE
feat!: Rework permission rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,20 @@ module App = {
 
 ### Create atoms
 
+#### Atom type
+
+Atoms have a value, a setter function (from `Atom.Actions`), and a set of tags that restrict which operations are allowed on the atom (e.g is the atom `#resettable`).
+Normally the type will be inferred automatically. If annotation is required it should be sufficient to provide the first type (the value).
+
+Example:
+
+```rescript
+let atom: Jotai.Atom.t<int, _, _> = Jotai.Atom.make(1)
+```
+
 #### Primitive atom (`Jotai.Atom.make`)
 
-Create a simple readable and writable atom.
+Create a (primitive) readable and writable atom.
 
 ```rescript
 let atom1 = Jotai.Atom.make(1)
@@ -51,7 +62,8 @@ let atom2 = Jotai.Atom.make('text')
 
 #### Computed atom (`Jotai.Atom.makeComputed`)
 
-Create a computed readonly atom. A computed atom can use any number of readable atoms to create a single combined value. The syntax varies slightly from Jotai. Note the curly braces in `({get})`.
+Create a computed readonly atom. A computed atom can combine any number of readable atoms to create a single derived value. The syntax varies slightly from Jotai.
+Note the curly braces in `({get})`.
 
 ```rescript
 let atom1 = Jotai.Atom.make(1)
@@ -61,8 +73,7 @@ let atom3 = Jotai.Atom.makeComputed(({get}) => get(atom1) + get(atom2) + 1)
 
 #### Computed async atom (`Jotai.Atom.makeComputedAsync`)
 
-Create an async computed readonly atom. All components will be notified when the returned promise resolves.
-This atom requires `React.Suspense` to work.
+(Requires React.Suspense) Create an computed readonly atom with an async getter. All components will be notified when the returned promise resolves.
 
 ```rescript
 let atom1 = Jotai.Atom.make(1)
@@ -110,11 +121,11 @@ let atom2 = Jotai.Atom.makeWritableComputedAsync(
 
 #### Computed writeonly atom (`Jotai.Atom.makeWriteOnlyComputed`)
 
-Create a writeOnly computed atom. (Note:The type can not be inferred automatically so it has to be annotated)
+Create a writeOnly computed atom.(Note: Sometimes the type can not be inferred and has to be annotated)
 
 ```rescript
 let atom1 = make(1)
-let atom2: Jotai.Atom.writeOnly<int> = Jotai.Atom.makeWriteOnlyComputed(({get, set}, args) =>
+let atom2: Jotai.Atom.t<int, _, _> = Jotai.Atom.makeWriteOnlyComputed(({get, set}, args) =>
   atom1->set(get(atom1) + args)
 )
 ```
@@ -132,11 +143,11 @@ atom1->Jotai.Atom.onMount(setAtom => {
 })
 ```
 
-### Hooks
+### Standard hook
 
-#### Use read/write atoms (`Jotai.Atom.use`)
+#### Using read/write atoms (`Jotai.Atom.use`)
 
-Standard hook to use with read/write atoms. If the atom or (in case of computed atoms) any atom that it is based on is async, the component has to be wrapped in `React.Suspense`.
+Standard hook to use with read/write atoms.
 (For handling of readOnly/writeOnly atoms see `Jotai.Utils`)
 
 ```rescript
@@ -148,7 +159,7 @@ let (value, setValue) = Jotai.Atom.use(atom1)
 
 #### Atom with localStorage (`Jotai.Utils.AtomWithStorage.make`)
 
-AtomWithStorage creates an atom with a value persisted in `localStorage`
+Creates an atom with a value persisted in `localStorage`
 Currently only `localStorage` is supported.
 
 ```rescript
@@ -157,24 +168,23 @@ let atom1 = Jotai.Utils.AtomWithStorage.make('storageKey', 1)
 
 #### Resettable atom (`Jotai.Utils.AtomWithReset.make`)
 
-Creates an atom that could be reset to its initialValue with `useResetAtom` hook.
-To pass this function to a computed atom, the `Resettable.unpack` function has to be used.
+Creates an atom that can be resetted to its initialValue with the `useResetAtom` hook.
 
 ```rescript
-let atom1 = Jotai.Utils.AtomWithReset.make(1)
-let atom2 = Jotai.Atom.makeComputed(({get}) => atom1->Resettable.unpack->get + 1)  // unpack atom first
+let atom = Jotai.Utils.AtomWithReset.make(1)
+// ... change value ...
+let reset = Jotai.Utils.useResetAtom(atom)
+reset()
 ```
 
 #### Atom with default (`Jotai.Utils.AtomWithDefault.make`)
 
-This is a function to create a _resettable_ primitive atom. Its default
-value can be specified with a read function instead of a static initial value.
-To pass this function to a computed atom, the `Resettable.unpack` function has to be used.
+Create a resettable primitive atom. Its default value can be specified
+with a read function instead of a static initial value.
 
 ```rescript
 let atom1 = Jotai.Atom.make(1)
-let atom2 = Jotai.Utils.AtomWithDefault.make(({get}) => get(atom1) + 1)
-let atom3 = Jotai.Atom.makeComputed(({get}) => atom2->Resettable.unpack->get + 1)  // unpack atom first
+let atom2 = Jotai.Utils.AtomWithDefault.make(({get}) => atom1->get + 1)
 ```
 
 #### Atom with Reducer (`Jotai.Utils.AtomWithReducer.make`)
@@ -183,39 +193,36 @@ Creates an atom that uses a reducer to update its value.
 
 ```rescript
 type actionType = Inc(int) | Dec(int)
-
 let countReducer = (prev, action) => {
   switch action {
   | Inc(num) => prev + num
   | Dec(num) => prev - num
   }
 }
-
-let atom1 = Jotai.Utils.AtomWithReducer.make(0, countReducer)
-
-let (value, dispatch) = Jotai.Atom.use(atom1)
+let atom = Utils.AtomWithReducer.make(0, countReducer)
+let (value, dispatch) = Atom.use(atom)
 Inc(1)->dispatch
 ```
 
 ### Utils Hooks
 
-#### Use only setValue (`Jotai.Utils.useUpdateAtom`)
+#### Get only the update function (`Jotai.Utils.useUpdateAtom`)
 
-A hook that only returns the update function of an atom. Can be used to access writeOnly atoms.
+A hook that returns only the update function of an atom. Can be used to access writeOnly atoms.
 
 ```rescript
-let atom1 = Jotai.Atom.make(1)
-let setValue = Jotai.Utils.useUpdateAtom(atom1)
-setValue(3)
+let atom = Jotai.Atom.make(1)
+let setValue = Jotai.Utils.useUpdateAtom(atom)
+setValue(prev => prev + 1)
 ```
 
-#### Use only the value (`Jotai.Utils.useAtomValue`)
+#### Get only the value (`Jotai.Utils.useAtomValue`)
 
-A hook that only returns the value of an atom. Can be used to access readOnly atoms.
+A hook that returns only the value of an atom. Can be used to access readOnly atoms.
 
 ```rescript
-let atom1 = Jotai.Atom.make(1)
-let value = Jotai.Utils.useAtomValue(atom1)
+let atom = Jotai.Atom.make(1)
+let value = Jotai.Utils.useAtomValue(atom)
 ```
 
 #### Reset an atom (`Jotai.Utils.useResetAtom`)
@@ -223,30 +230,27 @@ let value = Jotai.Utils.useAtomValue(atom1)
 Returns a function that can be used to reset a resettable atom.
 
 ```rescript
-let atom1 = Jotai.Utils.AtomWithReset(1)  // value: 1
-let (_, setValue) = Jotai.Atom.use(atom1)
+let atom = Jotai.Utils.AtomWithReset(1)  // value: 1
+let (_, setValue) = Jotai.Atom.use(atom)
 setValue(2)  // value: 2
-let resetValue = Jotai.Utils.useResetAtom(atom1)
+let resetValue = Jotai.Utils.useResetAtom(atom)
 resetValue()  // value back to: 1
 ```
 
 #### Pass a reducer to a writable atom (`Jotai.Utils.useReducerAtom`)
 
-Allows to use a reducer function with any (primitive) writable atom.
-(Note: If the atom is computed, the second argument passed to the setter function is the reducer itself.)
+Allows to use a reducer function with a primitive atom.
 
 ```rescript
 type actionType = Inc(int) | Dec(int)
-
 let countReducer = (prev, action) => {
   switch action {
   | Inc(num) => prev + num
   | Dec(num) => prev - num
   }
 }
-
-let atom1 = Jotai.Atom.make(0)
-let (value, dispatch) = Jotai.Utils.useReducerAtom(atom1, countReducer)
+let atom = Jotai.Atom.make(0)
+let (value, dispatch) = Jotai.Utils.useReducerAtom(atom, countReducer)
 Inc(1)->dispatch
 ```
 

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -2,7 +2,6 @@
   "name": "@fattafatta/rescript-jotai",
   "namespace": "jotai",
   "reason": { "react-jsx": 3 },
-  "bsc-flags": [],
   "sources": [
     {
       "dir": "src",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@fattafatta/rescript-zora-jsdom": "^0.1.1",
         "@testing-library/react-hooks": "^7.0.2",
         "jotai": "^1.4.6",
-        "onchange": "^7.1.0",
         "rescript": "^9.1.4",
         "rescript-hooks-testing-library": "^0.1.0"
       },
@@ -34,18 +33,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@blakeembrey/deque": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@blakeembrey/deque/-/deque-1.0.5.tgz",
-      "integrity": "sha512-6xnwtvp9DY1EINIKdTfvfeAtCYw4OqBZJhtiqkT3ivjnEfa25VQ3TsKvaFfKm8MyGIEfE95qLe+bNEt3nB0Ylg==",
-      "dev": true
-    },
-    "node_modules/@blakeembrey/template": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@blakeembrey/template/-/template-1.0.0.tgz",
-      "integrity": "sha512-J6WGZqCLdRMHUkyRG6fBSIFJ0rL60/nsQNh5rQvsYZ5u0PsKw6XQcJcA3DWvd9cN3j/IQx5yB1fexhCafwwUUw==",
-      "dev": true
     },
     "node_modules/@dusty-phillips/rescript-zora": {
       "version": "3.0.0",
@@ -261,23 +248,10 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
       "dev": true
     },
     "node_modules/array-union": {
@@ -294,15 +268,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/braces": {
       "version": "3.0.2",
@@ -322,27 +287,6 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
-    "node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-      "dev": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -359,20 +303,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/cssom": {
@@ -600,20 +530,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -706,18 +622,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -752,12 +656,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "node_modules/jotai": {
@@ -934,15 +832,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -955,24 +844,6 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/onchange": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/onchange/-/onchange-7.1.0.tgz",
-      "integrity": "sha512-ZJcqsPiWUAUpvmnJri5TPBooqJOPmC0ttN65juhN15Q8xA+Nbg3BaxBHXQ45EistKKlKElb0edmbPWnKSBkvMg==",
-      "dev": true,
-      "dependencies": {
-        "@blakeembrey/deque": "^1.0.5",
-        "@blakeembrey/template": "^1.0.0",
-        "arg": "^4.1.3",
-        "chokidar": "^3.3.1",
-        "cross-spawn": "^7.0.1",
-        "ignore": "^5.1.4",
-        "tree-kill": "^1.2.2"
-      },
-      "bin": {
-        "onchange": "dist/bin.js"
       }
     },
     "node_modules/optionator": {
@@ -997,15 +868,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -1070,12 +932,6 @@
       "peerDependencies": {
         "zora": "^5.0.0"
       }
-    },
-    "node_modules/pta/node_modules/arg": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
-      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -1154,18 +1010,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
@@ -1334,27 +1178,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -1416,15 +1239,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
-      "bin": {
-        "tree-kill": "cli.js"
       }
     },
     "node_modules/type-check": {
@@ -1512,21 +1326,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -1537,9 +1336,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
-      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
+      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -1591,12 +1390,6 @@
       "bin": {
         "zr": "src/bin.js"
       }
-    },
-    "node_modules/zora-reporters/node_modules/arg": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
-      "dev": true
     }
   },
   "dependencies": {
@@ -1608,18 +1401,6 @@
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
-    },
-    "@blakeembrey/deque": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@blakeembrey/deque/-/deque-1.0.5.tgz",
-      "integrity": "sha512-6xnwtvp9DY1EINIKdTfvfeAtCYw4OqBZJhtiqkT3ivjnEfa25VQ3TsKvaFfKm8MyGIEfE95qLe+bNEt3nB0Ylg==",
-      "dev": true
-    },
-    "@blakeembrey/template": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@blakeembrey/template/-/template-1.0.0.tgz",
-      "integrity": "sha512-J6WGZqCLdRMHUkyRG6fBSIFJ0rL60/nsQNh5rQvsYZ5u0PsKw6XQcJcA3DWvd9cN3j/IQx5yB1fexhCafwwUUw==",
-      "dev": true
     },
     "@dusty-phillips/rescript-zora": {
       "version": "3.0.0",
@@ -1785,20 +1566,10 @@
         "debug": "4"
       }
     },
-    "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      }
-    },
     "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
       "dev": true
     },
     "array-union": {
@@ -1811,12 +1582,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
     "braces": {
@@ -1834,22 +1599,6 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
-    "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-      "dev": true,
-      "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      }
-    },
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -1863,17 +1612,6 @@
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
-      }
-    },
-    "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
       }
     },
     "cssom": {
@@ -2046,13 +1784,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
     "glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -2121,15 +1852,6 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2155,12 +1877,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "jotai": {
@@ -2265,12 +1981,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
-    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -2281,21 +1991,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "onchange": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/onchange/-/onchange-7.1.0.tgz",
-      "integrity": "sha512-ZJcqsPiWUAUpvmnJri5TPBooqJOPmC0ttN65juhN15Q8xA+Nbg3BaxBHXQ45EistKKlKElb0edmbPWnKSBkvMg==",
-      "dev": true,
-      "requires": {
-        "@blakeembrey/deque": "^1.0.5",
-        "@blakeembrey/template": "^1.0.0",
-        "arg": "^4.1.3",
-        "chokidar": "^3.3.1",
-        "cross-spawn": "^7.0.1",
-        "ignore": "^5.1.4",
-        "tree-kill": "^1.2.2"
-      }
     },
     "optionator": {
       "version": "0.8.3",
@@ -2315,12 +2010,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
-    },
-    "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-type": {
@@ -2367,14 +2056,6 @@
         "arg": "~5.0.0",
         "globby": "~11.0.4",
         "zora-reporters": "^1.3.2"
-      },
-      "dependencies": {
-        "arg": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-          "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
-          "dev": true
-        }
       }
     },
     "punycode": {
@@ -2424,15 +2105,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
     },
     "regenerator-runtime": {
       "version": "0.13.9",
@@ -2565,21 +2237,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "^3.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
-    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2627,12 +2284,6 @@
       "requires": {
         "punycode": "^2.1.1"
       }
-    },
-    "tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -2698,15 +2349,6 @@
         "webidl-conversions": "^7.0.0"
       }
     },
-    "which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -2714,9 +2356,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
-      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
+      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
       "dev": true,
       "requires": {}
     },
@@ -2747,14 +2389,6 @@
         "arg": "~5.0.0",
         "colorette": "~1.2.2",
         "diff": "~5.0.0"
-      },
-      "dependencies": {
-        "arg": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
-          "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
-          "dev": true
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "build": "rescript",
     "build:deps": "rescript build -with-deps",
     "start": "rescript build -w -with-deps",
-    "test:watch": "npm run build && onchange --initial '{tests,src}/*.bs.js' -- pta 'test/*_test.bs.js'",
     "test": "npm run build && pta 'test/*_test.bs.js'"
   },
   "devDependencies": {
@@ -23,7 +22,6 @@
     "@fattafatta/rescript-zora-jsdom": "^0.1.1",
     "@testing-library/react-hooks": "^7.0.2",
     "jotai": "^1.4.6",
-    "onchange": "^7.1.0",
     "rescript": "^9.1.4",
     "rescript-hooks-testing-library": "^0.1.0"
   },

--- a/src/Atom.resi
+++ b/src/Atom.resi
@@ -1,33 +1,48 @@
-module Permissions: {
+module Tags: {
   type r = [#readable]
   type w = [#writable]
-  type rw = [#readable | #writable]
+  type p = [#primitive]
+  type re = [#resettable]
+  type all = [#primitive | #readable | #resettable | #writable]
 }
-type t<'value, 'a> constraint 'a = [< Permissions.rw]
-type readOnly<'value> = t<'value, Permissions.r>
-type readWrite<'value> = t<'value, Permissions.rw>
-type writeOnly<'value> = t<'value, Permissions.w>
-type readable<'value, 'perm> = t<'value, 'perm> constraint 'perm = [> Permissions.r]
-type writable<'value, 'perm> = t<'value, 'perm> constraint 'perm = [> Permissions.w]
-type getter = {get: 'value 'perm. readable<'value, 'perm> => 'value}
-type setter = {set: 'value 'perm. (writable<'value, 'perm>, 'value) => unit}
-type getterAndSetter = {
-  get: 'value 'perm. readable<'value, 'perm> => 'value,
-  set: 'value 'perm. (writable<'value, 'perm>, 'value) => unit,
+module Actions: {
+  type t<'action>
+  type set<'value> = t<('value => 'value) => unit>
+  type update<'value> = t<'value => unit>
+  type dispatch<'action> = t<'action => unit>
+}
+type t<'value, 'action, 'tags>
+  constraint 'tags = [< Tags.all] constraint 'action = Actions.t<'setValue>
+type void // used for readonly atoms without setter
+
+type set<'value, 'action, 'tags> = t<'value, 'action, 'tags> constraint 'tags = [> Tags.w]
+
+type get<'value, 'action, 'tags> = t<'value, 'action, 'tags> constraint 'tags = [> Tags.r]
+
+type getter = {get: 'value 'action 'tags. get<'value, Actions.t<'action>, 'tags> => 'value}
+type setter = {
+  get: 'value 'action 'tags. get<'value, Actions.t<'action>, 'tags> => 'value,
+  set: 'value 'setValue 'action 'tags. (set<'value, Actions.t<'action>, 'tags>, 'setValue) => unit,
 }
 type getValue<'value> = getter => 'value
 type getValueAsync<'value> = getter => Js.Promise.t<'value>
-type setValue<'args> = (getterAndSetter, 'args) => unit
-type setValueAsync<'args> = (getterAndSetter, 'args) => Js.Promise.t<unit>
+type setValue<'args> = (setter, 'args) => unit
+type setValueAsync<'args> = (setter, 'args) => Js.Promise.t<unit>
 @module("jotai")
-external make: 'value => readWrite<'value> = "atom"
-let makeComputed: getValue<'value> => readOnly<'value>
-let makeComputedAsync: getValueAsync<'value> => readOnly<'value>
-let makeWritableComputed: (getValue<'value>, setValue<'args>) => readWrite<'value>
-let makeWritableComputedAsync: (getValue<'value>, setValueAsync<'args>) => readWrite<'value>
-let makeWriteOnlyComputed: setValue<'a> => writeOnly<'b>
+external make: 'value => t<'value, Actions.set<'value>, [Tags.r | Tags.w | Tags.p]> = "atom"
+let makeComputed: getValue<'value> => t<'value, Actions.t<'a>, Tags.r>
+let makeComputedAsync: getValueAsync<'value> => t<'value, Actions.t<'a>, Tags.r>
+let makeWritableComputed: (
+  getValue<'value>,
+  setValue<'args>,
+) => t<'value, Actions.update<'args>, [Tags.r | Tags.w]>
+let makeWritableComputedAsync: (
+  getValue<'value>,
+  setValueAsync<'args>,
+) => t<'value, Actions.update<'args>, [#readable | #writable]>
+let makeWriteOnlyComputed: setValue<'a> => t<'b, Actions.update<'a>, Tags.w>
 @module("jotai")
-external use: readWrite<'value> => ('value, 'value => unit) = "useAtom"
+external use: t<'value, Actions.t<'action>, [> Tags.r | Tags.w]> => ('value, 'action) = "useAtom"
 type setAtom<'value> = ('value => 'value) => unit
 type onUnmount = unit => unit
-let onMount: (writable<'value, [< Permissions.w]>, setAtom<'value> => onUnmount) => unit
+let onMount: (t<'value, _, [> Tags.w]>, setAtom<'value> => onUnmount) => unit

--- a/src/Utils.res
+++ b/src/Utils.res
@@ -1,20 +1,3 @@
-// // atomWithStorage
-// @module("jotai/utils")
-// external atomWithStorage: (string, 'value) => Atom.readWrite<'value> = "atomWithStorage"
-
-// // atomWithReset
-// @module("jotai/utils")
-// external atomWithReset: 'value => Resettable.t<'value> = "atomWithReset"
-
-// // atomWithDefault
-// @module("jotai/utils")
-// external atomWithDefault: Atom.getValue<'value> => Resettable.t<'value> = "atomWithDefault"
-
-// // atomWithReducer
-// @module("jotai/utils")
-// external atomWithReducer: ('value, reducer<'value, 'action>) => withReducer<'value> =
-//   "atomWithReducer"
-
 module AtomWithStorage = Utils_AtomWithStorage
 
 module AtomWithDefault = Utils_AtomWithDefault
@@ -22,8 +5,6 @@ module AtomWithDefault = Utils_AtomWithDefault
 module AtomWithReset = Utils_AtomWithReset
 
 module AtomWithReducer = Utils_AtomWithReducer
-
-module Resettable = Utils_Resettable
 
 include Utils__Hooks
 

--- a/src/utils/Utils_AtomWithDefault.res
+++ b/src/utils/Utils_AtomWithDefault.res
@@ -1,15 +1,21 @@
-@ocaml.doc("This is a function to create a resettable primitive atom. Its default
-value can be specified with a read function instead of a static initial value.
-To pass this function to a computed atom, the `Resettable.unpack` function has to be used.
+@ocaml.doc("Create a resettable primitive atom. Its default value can be specified
+with a read function instead of a static initial value.
 
-Example:
-```
+```rescript
 let atom1 = Jotai.Atom.make(1)
-let atom2 = Jotai.Utils.AtomWithDefault.make(({get}) => get(atom1) + 1)
-let atom3 = Jotai.Atom.makeComputed(({get}) => atom2->Resettable.unpack->get + 1)  // unpack atom first
+let atom2 = Jotai.Utils.AtomWithDefault.make(({get}) => atom1->get + 1)
 ```
 ")
 @module("../wrapper")
-external make: Atom.getValue<'value> => Utils_Resettable.t<'value> = "atomWithDefaultWrapped"
-external makeAsync: Atom.getValueAsync<'value> => Utils_Resettable.t<'value> =
-  "atomWithDefaultWrapped"
+external make: Atom.getValue<'value> => Atom.t<
+  'value,
+  Atom.Actions.set<'value>,
+  [Atom.Tags.r | Atom.Tags.w | Atom.Tags.p | Atom.Tags.re],
+> = "atomWithDefaultWrapped"
+
+@module("../wrapper")
+external makeAsync: Atom.getValueAsync<'value> => Atom.t<
+  'value,
+  Atom.Actions.set<'value>,
+  [Atom.Tags.r | Atom.Tags.w | Atom.Tags.p | Atom.Tags.re],
+> = "atomWithDefaultWrapped"

--- a/src/utils/Utils_AtomWithReducer.res
+++ b/src/utils/Utils_AtomWithReducer.res
@@ -1,25 +1,23 @@
 type reducer<'value, 'action> = ('value, 'action) => 'value
 type dispatch<'action> = 'action => unit
-// type withReducer<'value> = Atom.readWrite<'value>
 
 @ocaml.doc("Creates an atom that uses a reducer to update its value.
 
-Example:
-```
+```rescript
 type actionType = Inc(int) | Dec(int)
-
 let countReducer = (prev, action) => {
   switch action {
   | Inc(num) => prev + num
   | Dec(num) => prev - num
   }
 }
-
-let atom1 = Jotai.Utils.AtomWithReducer.make(0, countReducer)
-
-let (value, dispatch) = Jotai.Atom.use(atom1)
+let atom = Utils.AtomWithReducer.make(0, countReducer)
+let (value, dispatch) = Atom.use(atom)
 Inc(1)->dispatch
 ```
 ")
 @module("jotai/utils")
-external make: ('value, reducer<'value, 'action>) => Atom.readWrite<'value> = "atomWithReducer"
+external make: (
+  'value,
+  reducer<'value, 'action>,
+) => Atom.t<'value, Atom.Actions.dispatch<'action>, [Atom.Tags.r | Atom.Tags.w]> = "atomWithReducer"

--- a/src/utils/Utils_AtomWithReset.res
+++ b/src/utils/Utils_AtomWithReset.res
@@ -1,11 +1,15 @@
-@ocaml.doc("Creates an atom that could be reset to its initialValue with `useResetAtom` hook.
-To pass this function to a computed atom, the `Resettable.unpack` function has to be used.
+@ocaml.doc("Creates an atom that can be resetted to its initialValue with the `useResetAtom` hook.
 
-Example:
-```
-let atom1 = Jotai.Utils.AtomWithReset.make(1)
-let atom2 = Jotai.Atom.makeComputed(({get}) => atom1->Resettable.unpack->get + 1)  // unpack atom first
+```rescript
+let atom = Jotai.Utils.AtomWithReset.make(1)
+// ... change value ...
+let reset = Jotai.Utils.useResetAtom(atom)
+reset()
 ```
 ")
 @module("jotai/utils")
-external make: 'value => Utils_Resettable.t<'value> = "atomWithReset"
+external make: 'value => Atom.t<
+  'value,
+  Atom.Actions.set<'value>,
+  [Atom.Tags.r | Atom.Tags.w | Atom.Tags.p | Atom.Tags.re],
+> = "atomWithReset"

--- a/src/utils/Utils_AtomWithStorage.res
+++ b/src/utils/Utils_AtomWithStorage.res
@@ -1,11 +1,14 @@
 // TODO Add support for additional storage options
-@ocaml.doc("AtomWithStorage creates an atom with a value persisted in `localStorage`
+@ocaml.doc("Creates an atom with a value persisted in `localStorage`
 Currently only `localStorage` is supported.
 
-Example:
-```
+```rescript
 let atom1 = Jotai.Utils.AtomWithStorage.make('storageKey', 1)
 ```
 ")
 @module("jotai/utils")
-external make: (string, 'value) => Atom.readWrite<'value> = "atomWithStorage"
+external make: (
+  string,
+  'value,
+) => Atom.t<'value, Atom.Actions.set<'value>, [Atom.Tags.r | Atom.Tags.w | Atom.Tags.p]> =
+  "atomWithStorage"

--- a/src/utils/Utils_Resettable.res
+++ b/src/utils/Utils_Resettable.res
@@ -1,5 +1,0 @@
-// TODO: Find a better way to handle resettable atoms that do not require the
-// `Resettable.unpack` function.
-
-type t<'value> = Atom.readWrite<'value>
-let unpack = r => r

--- a/src/utils/Utils_Resettable.resi
+++ b/src/utils/Utils_Resettable.resi
@@ -1,2 +1,0 @@
-type t<'value>
-let unpack: t<'value> => Atom.readWrite<'value>

--- a/src/utils/Utils__Hooks.res
+++ b/src/utils/Utils__Hooks.res
@@ -1,67 +1,61 @@
 // useUpdateAtom
-@ocaml.doc("A hook that only returns the update function of an atom. Can be used to access 
-writeOnly atoms.
+@ocaml.doc("A hook that returns only the update function of an atom. Can be used to access writeOnly atoms.
 
-Example:
-```
-let atom1 = Jotai.Atom.make(1)
-let setValue = Jotai.Utils.useUpdateAtom(atom1) 
-```
-")
-@module("jota/utils")
-external useUpdateAtom: Atom.writable<'value, _> => Atom.setAtom<'value> = "useUpdateAtom"
-
-// useAtomValue
-@ocaml.doc("A hook that only returns the value of an atom. Can be used to access 
-readOnly atoms.
-
-Example:
-```
-let atom1 = Jotai.Atom.make(1)
-let value = Jotai.Utils.useAtomValue(atom1) 
+```rescript
+let atom = Jotai.Atom.make(1)
+let setValue = Jotai.Utils.useUpdateAtom(atom) 
+setValue(prev => prev + 1)
 ```
 ")
 @module("jotai/utils")
-external useAtomValue: Atom.readable<'value, _> => 'value = "useAtomValue"
+external useUpdateAtom: Atom.t<'value, Atom.Actions.t<'action>, [> Atom.Tags.w]> => 'action =
+  "useUpdateAtom"
+
+// useAtomValue
+@ocaml.doc("A hook that returns only the value of an atom. Can be used to access 
+readOnly atoms.
+
+```rescript
+let atom = Jotai.Atom.make(1)
+let value = Jotai.Utils.useAtomValue(atom) 
+```
+")
+@module("jotai/utils")
+external useAtomValue: Atom.t<'value, _, [> Atom.Tags.r]> => 'value = "useAtomValue"
 
 // useResetAtom
 @ocaml.doc("Returns a function that can be used to reset a resettable atom.
 
-Example:
-```
-let atom1 = Jotai.Utils.AtomWithReset(1)  // value: 1
-let (_, setValue) = Jotai.Atom.use(atom1)
+```rescript
+let atom = Jotai.Utils.AtomWithReset(1)  // value: 1
+let (_, setValue) = Jotai.Atom.use(atom)
 setValue(2)  // value: 2
-let resetValue = Jotai.Utils.useResetAtom(atom1) 
+let resetValue = Jotai.Utils.useResetAtom(atom) 
 resetValue()  // value back to: 1
 ```
 ")
-type resetFunc = unit => unit
+type reset = unit => unit
 @module("jotai/utils")
-external useResetAtom: Utils_Resettable.t<'value> => resetFunc = "useResetAtom"
+external useResetAtom: Atom.t<'value, _, [> Atom.Tags.re]> => reset = "useResetAtom"
 
 // useReducerAtom
-@ocaml.doc("Allows to use a reducer function with a (primitive) writable atom.
-(Note: Behaves differently with computed atoms)
+@ocaml.doc("Allows to use a reducer function with a primitive atom.
 
-Example:
-```
+```rescript
 type actionType = Inc(int) | Dec(int)
-
 let countReducer = (prev, action) => {
   switch action {
   | Inc(num) => prev + num
   | Dec(num) => prev - num
   }
 }
-
-let atom1 = Jotai.Atom.make(0)
-let (value, dispatch) = Jotai.Utils.useReducerAtom(atom1, countReducer)
+let atom = Jotai.Atom.make(0)
+let (value, dispatch) = Jotai.Utils.useReducerAtom(atom, countReducer)
 Inc(1)->dispatch
 ```
 ")
 @module("jotai/utils")
 external useReducerAtom: (
-  Atom.readWrite<'value>,
+  Atom.t<'value, _, [> Atom.Tags.p]>,
   Utils_AtomWithReducer.reducer<'value, 'action>,
 ) => ('value, Utils_AtomWithReducer.dispatch<'action>) = "useReducerAtom"

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { atom } = require('jotai');
 const { atomWithDefault } = require('jotai/utils')
 
@@ -23,14 +22,15 @@ exports.atomWrapped = (getFunc, writeFunc) => {
       // that is only used internally. But it messes up the Curry._1 function used by rescript. Keeping the
       // optional parameter would make the function signature unnecessarily complex.
       const getWithoutOptions = a => get(a, undefined);
-      writeFunc({ get: getWithoutOptions, set }, args);
+      writeFunc({ get: getWithoutOptions, set, dispatch: set }, args);
     },
   );
 };
 
-exports.onMount = (atom, setter) => {
-  return atom.onMount(setter)
+exports.onMount = (anAtom, setter) => {
+  anAtom.onMount = setter
 }
+exports.something = undefined
 
 exports.atomWithDefaultWrapped = (getFunc) => {
   return atomWithDefault(

--- a/test/Atom_test.res
+++ b/test/Atom_test.res
@@ -7,7 +7,7 @@ zoraWithDOM("standard atom", t => {
   let {result} = renderHook(() => Atom.use(a), ())
   let (value, setValue) = result.current
   t->equal(value, 1, "should be 1")
-  act(() => setValue(2))
+  act(() => setValue(p => p + 1))
   let (value, _) = result.current
   t->equal(value, 2, "should be 2")
   done()
@@ -20,7 +20,7 @@ zoraWithDOM("computed readonly atom", t => {
   let {result: r2} = renderHook(() => Utils.useAtomValue(c), ())
   t->equal(r2.current, 2, "should be 2")
   let (_, setValue) = r1.current
-  act(() => setValue(2))
+  act(() => setValue(p => p + 1))
   t->equal(r2.current, 3, "should be 3")
   done()
 })

--- a/test/Utils_test.res
+++ b/test/Utils_test.res
@@ -4,31 +4,104 @@ open RescriptHooksTestingLibrary.Testing
 
 @val external window: 'w = "window"
 
-zoraWithDOM("atom with storage", t => {
+zoraWithDOM("AtomWithStorage", t => {
   let a = Utils.AtomWithStorage.make("mykey", 1)
   let {result} = renderHook(() => Atom.use(a), ())
   let (value, setValue) = result.current
   t->equal(value, 1, "should be 1")
-  act(() => setValue(2))
+  act(() => setValue(p => p + 1))
   let fromStorage =
     window["localStorage"]["getItem"]("mykey")->Belt.Int.fromString->Belt.Option.getUnsafe
   t->equal(fromStorage, 2, "localStorage should be 2")
   done()
 })
 
-zoraWithDOM("atom with default", t => {
+zoraWithDOM("AtomWithDefault", t => {
   let a = Atom.make(1)
   let b = Utils.AtomWithDefault.make(({get}) => a->get + 1)
-  let {result} = renderHook(() => Atom.use(b->Utils.Resettable.unpack), ())
+  let {result} = renderHook(() => Atom.use(b), ())
   let (value, setValue) = result.current
   t->equal(value, 2, "should be 2")
-  act(() => setValue(1))
+  act(() => setValue(_ => 1))
   let (value, _) = result.current
   t->equal(value, 1, "should be 1 after update")
   let {result} = renderHook(() => Utils.useResetAtom(b), ())
   result.current()
-  let {result} = renderHook(() => Atom.use(b->Utils.Resettable.unpack), ())
+  let {result} = renderHook(() => Atom.use(b), ())
   let (value, _) = result.current
   t->equal(value, 2, "should be 2 again after reset")
+  done()
+})
+
+zoraWithDOM("AtomWithReset", t => {
+  let a = Utils.AtomWithReset.make(1)
+  let {result} = renderHook(() => Atom.use(a), ())
+  let (value, setValue) = result.current
+  t->equal(value, 1, "should be 1")
+  act(() => setValue(p => p + 1))
+  let (value, _) = result.current
+  t->equal(value, 2, "should be 2 after update")
+  let {result} = renderHook(() => Utils.useResetAtom(a), ())
+  result.current()
+  let {result} = renderHook(() => Atom.use(a), ())
+  let (value, _) = result.current
+  t->equal(value, 1, "should be 1 again after reset")
+  done()
+})
+
+type actionType = Inc(int) | Dec(int)
+
+zoraWithDOM("AtomWithReducer", t => {
+  let countReducer = (prev, action) => {
+    switch action {
+    | Inc(num) => prev + num
+    | Dec(num) => prev - num
+    }
+  }
+  let a = Utils.AtomWithReducer.make(0, countReducer)
+  let {result} = renderHook(() => Atom.use(a), ())
+  let (value, dispatch) = result.current
+  t->equal(value, 0, "should be 0")
+  act(() => Inc(1)->dispatch)
+  let (value, _) = result.current
+  t->equal(value, 1, "should be 1 after update")
+  done()
+})
+
+zoraWithDOM("useReducerAtom hook", t => {
+  let countReducer = (prev, action) => {
+    switch action {
+    | Inc(num) => prev + num
+    | Dec(num) => prev - num
+    }
+  }
+  let a = Atom.make(1)
+  let {result} = renderHook(() => Utils.useReducerAtom(a, countReducer), ())
+  let (value, dispatch) = result.current
+  t->equal(value, 1, "should be 1")
+  act(() => Inc(1)->dispatch)
+  let (value, _) = result.current
+  t->equal(value, 2, "should be 2 after update")
+  done()
+})
+
+zoraWithDOM("useUpdateAtom hook", t => {
+  let a = Atom.make(1)
+  let {result} = renderHook(() => Utils.useUpdateAtom(a), ())
+  let setValue = result.current
+  act(() => setValue(p => p + 1))
+  let {result} = renderHook(() => Atom.use(a), ())
+  let (value, _) = result.current
+  t->equal(value, 2, "should be 2")
+  done()
+})
+
+zoraWithDOM("useAtomValue hook", t => {
+  let a = Atom.make(1)
+  let {result} = renderHook(() => Atom.use(a), ())
+  let (_, setValue) = result.current
+  act(() => setValue(p => p + 1))
+  let {result} = renderHook(() => Utils.useAtomValue(a), ())
+  t->equal(result.current, 2, "should be 2")
   done()
 })


### PR DESCRIPTION
Permissions were not flexible enough to handle all possible
usage scenarios for atoms.

Renamed permissions to tags sinc thw old nam didn't fit anymore.