### PR TITLE
fix: prevent argument mixup with writeOnlyComputed

### DIFF
--- a/src/Atom.res
+++ b/src/Atom.res
@@ -138,7 +138,7 @@ external makeWritableComputedAsync: (
 ) => t<'value, Actions.update<'args>, [Tags.r | Tags.w]> = "atomWrapped"
 
 @module("./wrapper")
-external _makeWOC: (unit, setValue<'args>) => t<'value, Actions.update<'args>, [Tags.w]> =
+external _makeWOC: (Js.Nullable.t<void>, setValue<'args>) => t<'value, Actions.update<'args>, [Tags.w]> =
   "atomWrapped"
 
 @ocaml.doc("Create a writeOnly computed atom.
@@ -151,7 +151,7 @@ let atom2: Jotai.Atom.t<int, _, _> = Jotai.Atom.makeWriteOnlyComputed(({get, set
 )
 ```
 ")
-let makeWriteOnlyComputed = getSet => _makeWOC((), getSet)
+let makeWriteOnlyComputed = getSet => _makeWOC(Js.Nullable.null, getSet)
 
 // HOOKS
 @ocaml.doc("Standard hook to use with read/write atoms.

--- a/test/Atom_test.res
+++ b/test/Atom_test.res
@@ -51,3 +51,19 @@ zoraWithDOM("computed writable atom", t => {
 //   })
 //   done()
 // })
+
+
+zoraWithDOM("computed writeonly atom", t => {
+  let a = Atom.make(1)
+  let b: Atom.t<int, _, _> = Atom.makeWriteOnlyComputed(
+  ({set, _}, id) => {
+    a->set(id)
+  })
+  let {result} = renderHook(() => Utils.useUpdateAtom(b), ())
+  let setValue = result.current
+  act(() => setValue(2))
+  let {result} = renderHook(() => Atom.use(a), ())
+  let (value, _) = result.current
+  t->equal(value, 2, "should be 2")
+  done()
+})


### PR DESCRIPTION
Passing unit resulted in ReScript discarding the parameter, but Jotai expects
a null value.