### PR TITLE
Fixes Store.get/set compilation

### DIFF
--- a/src/Store.res
+++ b/src/Store.res
@@ -32,8 +32,8 @@ type sup<'value, 'action, 'tags> = (
 let value = Jotai.Store.get(store, atom); 
 ```
 */
-@get
-external get: t => get<'value, _, _> = "get"
+@send
+external get: (t, Atom.t<'value, _, [> Atom.Tags.r]>) => 'value = "get"
 
 /** Sets a new value of a given atom in the store.
 
@@ -41,10 +41,37 @@ external get: t => get<'value, _, _> = "get"
 Jotai.Store.set(store, atom, 1); 
 ```
 */
-@get
-external set: t => set<'value, _, _> = "set"
+@send
+external set: (t, Atom.t<'value, Jotai.Atom.Actions.set<'value>, [> Atom.Tags.w]>, 'value) => unit =
+  "set"
 
-/** Subscripe to changes of a given atom in the store. Returns a function to unsubscribe.
+/** Sets a new value of a writable computed atom in the store.
+
+```rescript
+Jotai.Store.update(store, atom, (value) => value + 1);
+```
+*/
+@send
+external update: (
+  t,
+  Atom.t<'value, Jotai.Atom.Actions.update<'value>, [> Atom.Tags.w]>,
+  'value,
+) => unit = "set"
+
+/** Sets a new value of a given reducer atom in the store.
+
+```rescript
+Jotai.Store.dispatch(store, atom, Inc(1)); 
+```
+*/
+@send
+external dispatch: (
+  t,
+  Atom.t<'value, Jotai.Atom.Actions.dispatch<'action>, [> Atom.Tags.w]>,
+  'action,
+) => unit = "set"
+
+/** Subscribe to changes of a given atom in the store. Returns a function to unsubscribe.
 
 ```rescript
 let unsub = Jotai.Store.sub(store, atom, () => {
@@ -54,8 +81,8 @@ let unsub = Jotai.Store.sub(store, atom, () => {
 // unsub() to unsubscribe
 ```
 */
-@get
-external sub: t => sup<_, _, _> = "sub"
+@send
+external sub: (t, Atom.t<_, _, [> Atom.Tags.r]>, @uncurry unit => unit) => unitToUnitFunc = "sub"
 
 /** This hook returns a store within the component tree.
 

--- a/test/Store_test.res
+++ b/test/Store_test.res
@@ -1,0 +1,79 @@
+open Jest
+open Expect
+
+type actionType = Inc(int) | Dec(int)
+
+describe("Store", () => {
+  let store = Store.make()
+  let atom = Atom.make(0)
+
+  test("should be able to create a store", () => {
+    expect(store)->Expect.toMatchObject({
+      "get": ExpectStatic.anything(),
+      "set": ExpectStatic.anything(),
+      "sub": ExpectStatic.anything(),
+    })
+  })
+
+  test("should be able to get a value from a store", () => {
+    let value = Store.get(store, atom)
+    expect(value)->toBe(0)
+  })
+
+  test("should be able to set a value to a store", () => {
+    Store.set(store, atom, 1)
+    let value = store->Store.get(atom)
+    expect(value)->toBe(1)
+  })
+
+  test("should be able to dispatch an action to the store", () => {
+    let atom = Utils.AtomWithReducer.make(
+      0,
+      (prev, action) => {
+        switch action {
+        | Inc(num) => prev + num
+        | Dec(num) => prev - num
+        }
+      },
+    )
+    Store.dispatch(store, atom, Inc(1))
+    let value = store->Store.get(atom)
+    expect(value)->toBe(1)
+
+    Store.dispatch(store, atom, Dec(1))
+    let value = store->Store.get(atom)
+    expect(value)->toBe(0)
+  })
+
+  test("should be able to update a writable computed", () => {
+    let innerAtom = Atom.make(0)
+    let atom = Atom.makeWritableComputed(
+      ({get}) => get(innerAtom),
+      ({get, set}, arg) => {
+        set(innerAtom, get(innerAtom) + arg)
+      },
+    )
+
+    Store.update(store, atom, 1)
+    let value = store->Store.get(atom)
+    expect(value)->toBe(1)
+  })
+
+  let spy = Jest.Mock.make(() => ())
+  let callback = Jest.Mock.fn(spy)
+  let unsubscribe = store->Store.sub(atom, callback)
+
+  beforeEach(() => {
+    Mock.mockReset(spy)
+  })
+
+  afterAll(() => {
+    unsubscribe()
+  })
+
+  test("should be able to subscribe to a store", () => {
+    expect(spy)->toBeCalledTimes(0)
+    Store.set(store, atom, 2)
+    expect(spy)->toBeCalledTimes(1)
+  })
+})


### PR DESCRIPTION
These were compiling to `Curry_n` function calls resulting in some runtime errors when used. I tried for a bit to use the general form of `Atom.Actions.t` but it ends up resulting in unsafe behavior being compiled, like setting a new state to a reducer atom instead of only the action being allowed. If there's a better way to accomplish this without introducing the different `set/update/dispatch` bindings (or if you prefer different naming) let me know and we can adjust it.