### PR TITLE
fix import issue on case-sensitive file system when using useStore

### DIFF
--- a/src/Store.res
+++ b/src/Store.res
@@ -90,5 +90,5 @@ external sub: (t, Atom.t<_, _, [> Atom.Tags.r]>, @uncurry unit => unit) => unitT
 let store = Jotai.Store.useStore()
 ```
 */
-@module("Jotai")
+@module("jotai")
 external useStore: unit => t = "useStore"


### PR DESCRIPTION
I was having issues on a file where rescript was importing Jotai twice, one with lowercase and one with uppercase, I found the issue was related with useStore.
~I don't know if there's other casing issue in the codebase as I didn't check yet~
I just checked and it seems the only place it was misstyped.